### PR TITLE
Add automatic Sequence Derivation and Type Instance Derivation

### DIFF
--- a/core-catcher.cabal
+++ b/core-catcher.cabal
@@ -25,8 +25,9 @@ library
                      , App.State
                      , App.ConnectionMgnt
                      , App.Connection
-
                      , TH.MonoDerive
+                     , TH.TypeFamily
+                     , TH.MonoFunctions
 
   ghc-options:         -Wall
   build-depends:       base >= 4.7 && < 5

--- a/src/Network/Protocol.hs
+++ b/src/Network/Protocol.hs
@@ -328,7 +328,5 @@ Derive.deriveMap ''EnergyMap
 Derive.deriveMap ''PlayerEnergies
 -- MonoFoldable and MonoTraversable and IsSequence for RogueHistory
 Derive.deriveSequence ''RogueHistory
-type instance Element RogueHistory = (Energy, Maybe Node)
 -- MonoFoldable and MonoTraversable and IsSequence for RogueHistory
 Derive.deriveSequence ''OpenRogueHistory
-type instance Element OpenRogueHistory = (Energy, Node, Bool)

--- a/src/TH/MonoFunctions.hs
+++ b/src/TH/MonoFunctions.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module TH.MonoFunctions where
+
+
+import           ClassyPrelude
+import           Language.Haskell.TH
+
+simpleWrap :: Name -> Name -> DecQ
+simpleWrap funcName typeName = do
+    con <- getNewTypeCon typeName
+    let bodyExpr = [e| $(conE con) $(varE funcName) |]
+    let cl = clause
+            []
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleWrap1 :: Name -> Name -> DecQ
+simpleWrap1 funcName typeName = do
+    con <- getNewTypeCon typeName
+    let bodyExpr = [e| $(conE con) . $(varE funcName) |]
+    let cl = clause
+            []
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleWrap2 :: Name -> Name -> DecQ
+simpleWrap2 funcName typeName = do
+    con <- getNewTypeCon typeName
+    keyVar <- newName "k"
+    valueVar <- newName "v"
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE keyVar) $(varE valueVar) |]
+    let cl = clause
+            [ varP keyVar
+            , varP valueVar
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simplePattern :: Name -> Name -> DecQ
+simplePattern funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    let bodyExpr = [e| $(varE funcName) $(varE conVar) |]
+    let cl = clause
+            [ conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleUnwrap :: Name -> Name -> DecQ
+simpleUnwrap funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    otherVar <- newName "p"
+    let bodyExpr = [e| $(varE funcName) $(varE otherVar) $(varE conVar) |]
+    let cl = clause
+            [ varP otherVar
+            , conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleUnwrap1 :: Name -> Name -> DecQ
+simpleUnwrap1 funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    let bodyExpr = [e| $(varE funcName) $(varE conVar) |]
+    let cl = clause
+            [ conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+
+simpleUnwrapWrap :: Name -> Name -> DecQ
+simpleUnwrapWrap funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE conVar) |]
+    let cl = clause
+            [ conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleUnwrapWrap1' :: Name -> Name -> DecQ
+simpleUnwrapWrap1' funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    keyVar <- newName "k"
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE conVar) $(varE keyVar) |]
+    let cl = clause
+            [ conP con [varP conVar]
+            , varP keyVar
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleUnwrapWrap1 :: Name -> Name -> DecQ
+simpleUnwrapWrap1 funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    keyVar <- newName "k"
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE keyVar) $(varE conVar) |]
+    let cl = clause
+            [ varP keyVar
+            , conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleUnwrapWrap2 :: Name -> Name -> DecQ
+simpleUnwrapWrap2 funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    keyVar <- newName "k"
+    valueVar <- newName "v"
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE keyVar) $(varE valueVar) $(varE conVar) |]
+    let cl = clause
+            [ varP keyVar
+            , varP valueVar
+            , conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleFold :: Name -> Name -> DecQ
+simpleFold funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    funName <- newName "f"
+    accName <- newName "acc"
+    let bodyExpr = [e| $(varE funcName) $(varE funName) $(varE accName) $(varE conVar) |]
+    let cl = clause
+            [ varP funName
+            , varP accName
+            , conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleFold1 :: Name -> Name -> DecQ
+simpleFold1 funcName typeName = do
+    con <- getNewTypeCon typeName
+    conVar <- newName "a"
+    funName <- newName "f"
+    let bodyExpr = [e| $(varE funcName) $(varE funName) $(varE conVar) |]
+    let cl = clause
+            [ varP funName
+            , conP con [varP conVar]
+            ]
+            (normalB bodyExpr)
+            []
+    funD funcName [cl]
+
+simpleMap :: Name -> Name -> DecQ
+simpleMap funcName name = do
+    con <- getNewTypeCon name
+    conVar <- newName "a"
+    funName <- newName "f"
+    let typePat = conP con [varP conVar]
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE funName) $(varE conVar) |]
+    let cl = clause [varP funName, typePat] (normalB bodyExpr) []
+    funD funcName [cl]
+
+simpleBinOp :: Name -> Name -> DecQ
+simpleBinOp funcName name = do
+    con <- getNewTypeCon name
+    firstName <- newName "a"
+    secondName <- newName "b"
+    let firstPat = conP con [varP firstName]
+    let secondPat = conP con [varP secondName]
+    let bodyExpr = [e| $(conE con) $ $(varE funcName) $(varE firstName) $(varE secondName) |]
+    let cl = clause [firstPat, secondPat] (normalB bodyExpr) []
+    funD funcName [cl]
+
+
+getNewTypeCon :: Name -> Q Name
+getNewTypeCon typeName = do
+    TyConI mn <- reify typeName
+    case mn of
+      (NewtypeD _ _ _ _ (RecC con _) _) -> return con
+      (NewtypeD _ _ _ _ (NormalC con _) _) -> return con
+      _ -> fail "Only Newtype datastructures are allowed"

--- a/src/TH/TypeFamily.hs
+++ b/src/TH/TypeFamily.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module TH.TypeFamily
+  ( deriveNewtypedTypeFamily
+  )
+  where
+
+
+import           ClassyPrelude
+import           Language.Haskell.TH
+
+deriveNewtypedTypeFamily :: Name -> Name -> DecsQ
+deriveNewtypedTypeFamily typeFamily newtypeName = do
+    decl <- getDeclaration
+    instances <- getInstances decl
+    isInstance' <- isInstance typeFamily [decl]
+    newInstances <- sequenceA $ getTypeSynInstances decl instances
+    return newInstances
+    where
+        getInstances :: Type -> Q [InstanceDec]
+        getInstances newtypeName' = do
+            inst <- reifyInstances typeFamily [newtypeName']
+            return inst
+
+        getDeclaration :: Q Type
+        getDeclaration = do
+            TyConI mn <- reify newtypeName
+            case mn of
+                (NewtypeD _ _ _ _ (RecC _ [(_,_, typeD)]) _) -> do
+                    return typeD
+
+                (NewtypeD _ _ _ _ (NormalC _ [(_, typeD)]) _) -> do
+                    return typeD
+
+                _ ->
+                    fail $ show newtypeName ++ "Not a newtype"
+
+
+        getTypeSynInstances :: Type -> [InstanceDec] -> [DecQ]
+        getTypeSynInstances dec inst =
+            map
+                ( \(TySynInstD _ (TySynEqn c right)) -> do
+                    [newRight] <- sequenceA $ map (\f -> extractCorrectRightSide f dec right) c
+                    return $ TySynInstD typeFamily (TySynEqn [ConT newtypeName] newRight)
+                )
+                inst
+
+extractCorrectRightSide :: Type -> Type -> Type -> Q Type
+extractCorrectRightSide (AppT a b) (AppT c d) right =
+  if right == a then
+      return c
+  else if right == b then
+      return d
+  else
+      recover
+          (extractCorrectRightSide a c right)
+          (extractCorrectRightSide b d right)
+
+extractCorrectRightSide (ParensT a) (ParensT b) right =
+    if right == a then
+      return b
+    else
+      extractCorrectRightSide a b right
+
+extractCorrectRightSide ListT ListT ListT =
+    return ListT
+
+extractCorrectRightSide _ _ _ =
+    fail "Could not find a fitting type"


### PR DESCRIPTION
Refactored files
Infer `type instance` based on `newtype` content. 
Example for a given type instance `Element` assume the following definition. Example taken from ClassyPrelude.
```haskell
type Element [a] = a
```

For a type `newtype Tuple = Tuple [(Int, Int)]`, the following type will be derived:
```haskell
type Element Tuple = (Int, Int)
```

This inference rule is based on the right hand side type variable binding of the initial instance of `[a]`. 
The inference only works, if the right hand side is based on some type in the original instance. For example it is impossible to derive `type Index Tuple = Int` for `Int` is arbitrary chosen. However, I might add an option to automatically default to the old value, if no fitting inference can be performed.

There is still a lack of documentation, so this branch is not ready to merge yet.